### PR TITLE
Included further options for tourists from outside EEA

### DIFF
--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_standard_visit.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_standard_visit.govspeak.erb
@@ -1,12 +1,28 @@
 <% content_for :title do %>
-  You’ll need a visa to come to the UK
+  You may need a visa to come to the UK
 <% end %>
 
 <% content_for :body do %>
-  Apply for a [Standard Visitor visa](/standard-visitor-visa) if you’re visiting the UK for a holiday or to visit family or friends.
+  What you need to do depends on who you’re travelling with or visiting in the UK.
+
+##You’re travelling with or visiting your partner or family
+
+You don’t need a visa if both the following apply:
+
+- you have an [Article 10 residence card](/government/publications/entering-the-uk-as-the-holder-of-an-article-10-residence-card/entering-the-uk-as-the-holder-of-an-article-10-residence-card)
+- your partner or family member is your sponsor  
+
+Otherwise, you should apply for a:
+
+- [family permit](/family-permit) if your family member or partner are from the [European Economic Area (EEA)](/eu-eea)
+- [Standard Visitor visa](/standard-visitor-visa), if they’re from outside the EEA
+
+##You’re travelling alone, or travelling with or visiting friends
+
+Apply for a [Standard Visitor visa](/standard-visitor-visa).
 
   <% if calculator.passport_country_is_china? %>
-    ##Travelling in a tour group
+    ##You're travelling in a tour group
 
     You can apply for an [‘ADS visa’](/ads-visa) if you’re planning to travel to the UK as part of a tour group for less than 30 days.
   <% end %>


### PR DESCRIPTION
I've added further options for tourists from non-EEA countries wishing to enter the UK for a short stay. This is a short-term fix: the text is doing too much heavy lifting at present, so I've raised a ticket to make changes to the flow. But at least the info we're giving is correct.

Here's an example of an outcome that'll change once these changes go live: https://www.gov.uk/check-uk-visa/y/russia/tourism